### PR TITLE
fix lint error: React hook name must start with 'use'

### DIFF
--- a/plugins/dapr/src/components/ApplicationActorsCard/ApplicationActorsCard.tsx
+++ b/plugins/dapr/src/components/ApplicationActorsCard/ApplicationActorsCard.tsx
@@ -5,21 +5,22 @@ import { Typography } from '@material-ui/core';
 import { columns, useStyles } from './tableHeading';
 import { daprApiRef } from '../../api';
 import { MetadataActors } from '../../types';
-import { daprApplicationId } from '../../utils/isDaprAvailable';
-import { daprUI } from '../../utils/isDaprUiConfigured';
+import { useDaprApplicationId } from '../../utils/isDaprAvailable';
+import { useDaprUI } from '../../utils/isDaprUiConfigured';
 
 export const ApplicationActorsCard = () => {
-  const applicationId = daprApplicationId();
+  const applicationId = useDaprApplicationId();
   const DaprAPI = useApi(daprApiRef);
   const [data, setData] = useState<MetadataActors[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const classes = useStyles();
 
-  const title = daprUI() ? (
+  const daprUIUrl = useDaprUI();
+  const title = daprUIUrl ? (
     <>
       {`Dapr actors: `}
-      <Link to={`${daprUI()}/${applicationId}`}>{`${applicationId}`}</Link>
+      <Link to={`${daprUIUrl}/${applicationId}`}>{`${applicationId}`}</Link>
     </>
   ) : (
     `Dapr actors: ${applicationId}`

--- a/plugins/dapr/src/components/ApplicationComponentsCard/ApplicationComponentsCard.tsx
+++ b/plugins/dapr/src/components/ApplicationComponentsCard/ApplicationComponentsCard.tsx
@@ -4,22 +4,23 @@ import { useApi } from '@backstage/core-plugin-api';
 import { Typography } from '@material-ui/core';
 import { columns, useStyles } from './tableHeading';
 import { daprApiRef } from '../../api';
-import { daprApplicationId } from '../../utils/isDaprAvailable';
+import { useDaprApplicationId } from '../../utils/isDaprAvailable';
 import { Component } from '../../types';
-import { daprUI } from '../../utils/isDaprUiConfigured';
+import { useDaprUI } from '../../utils/isDaprUiConfigured';
 
 export const ApplicationComponentsCard = () => {
-  const applicationId = daprApplicationId();
+  const applicationId = useDaprApplicationId();
   const DaprAPI = useApi(daprApiRef);
   const [data, setData] = useState<Component[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const classes = useStyles();
 
-  const title = daprUI() ? (
+  const daprUIUrl = useDaprUI();
+  const title = daprUIUrl ? (
     <>
       {`Dapr Components: `}
-      <Link to={`${daprUI()}/${applicationId}`}>{`${applicationId}`}</Link>
+      <Link to={`${daprUIUrl}/${applicationId}`}>{`${applicationId}`}</Link>
     </>
   ) : (
     `Dapr components: ${applicationId}`

--- a/plugins/dapr/src/components/ApplicationSubscriptionsCard/ApplicationSubscriptionsCard.tsx
+++ b/plugins/dapr/src/components/ApplicationSubscriptionsCard/ApplicationSubscriptionsCard.tsx
@@ -5,21 +5,22 @@ import { Typography } from '@material-ui/core';
 import { columns, useStyles } from './tableHeading';
 import { daprApiRef } from '../../api';
 import { Subscription } from '../../types';
-import { daprApplicationId } from '../../utils/isDaprAvailable';
-import { daprUI } from '../../utils/isDaprUiConfigured';
+import { useDaprApplicationId } from '../../utils/isDaprAvailable';
+import { useDaprUI } from '../../utils/isDaprUiConfigured';
 
 export const ApplicationSubscriptionsCard = () => {
-  const applicationId = daprApplicationId();
+  const applicationId = useDaprApplicationId();
   const DaprAPI = useApi(daprApiRef);
   const [data, setData] = useState<Subscription[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const classes = useStyles();
 
-  const title = daprUI() ? (
+  const daprUIUrl = useDaprUI();
+  const title = daprUIUrl ? (
     <>
       {`Dapr Subscriptions: `}
-      <Link to={`${daprUI()}/${applicationId}`}>{`${applicationId}`}</Link>
+      <Link to={`${daprUIUrl}/${applicationId}`}>{`${applicationId}`}</Link>
     </>
   ) : (
     `Dapr Subscriptions: ${applicationId}`

--- a/plugins/dapr/src/components/ApplicationSummaryCard/ApplicationSummaryCard.tsx
+++ b/plugins/dapr/src/components/ApplicationSummaryCard/ApplicationSummaryCard.tsx
@@ -17,21 +17,22 @@ import {
 } from '@material-ui/core';
 import { daprApiRef } from '../../api';
 import { ApplicationInstance } from '../../types';
-import { daprApplicationId } from '../../utils/isDaprAvailable';
-import { daprUI } from '../../utils/isDaprUiConfigured';
+import { useDaprApplicationId } from '../../utils/isDaprAvailable';
+import { useDaprUI } from '../../utils/isDaprUiConfigured';
 
 export const ApplicationSummaryCard = () => {
-  const applicationId = daprApplicationId();
+  const applicationId = useDaprApplicationId();
   const DaprAPI = useApi(daprApiRef);
   const [data, setData] = useState<ApplicationInstance | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [openManifest, setOpenManifest] = useState(false);
 
-  const title = daprUI() ? (
+  const daprUIUrl = useDaprUI();
+  const title = daprUIUrl ? (
     <>
       {`Darp Application Instance: `}
-      <Link to={`${daprUI()}/${applicationId}`}>{`${applicationId}`}</Link>
+      <Link to={`${daprUIUrl}/${applicationId}`}>{`${applicationId}`}</Link>
     </>
   ) : (
     `Darp Application Instance: ${applicationId}`

--- a/plugins/dapr/src/index.ts
+++ b/plugins/dapr/src/index.ts
@@ -8,4 +8,4 @@ export {
 } from './plugin';
 export * from './api';
 export { isDaprAvailable } from './utils/isDaprAvailable';
-export { daprUI } from './utils/isDaprUiConfigured';
+export { useDaprUI } from './utils/isDaprUiConfigured';

--- a/plugins/dapr/src/utils/isDaprAvailable.ts
+++ b/plugins/dapr/src/utils/isDaprAvailable.ts
@@ -2,7 +2,7 @@ import { DAPR_APPLICATION_ID } from '../annotations';
 import { Entity } from '@backstage/catalog-model';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-/**
+/** 
  * Returns true if the catalog entity contains the dapr annotation `dapr.io/application-id`.
  *
  * @public
@@ -11,7 +11,7 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 export const isDaprAvailable = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[DAPR_APPLICATION_ID]);
 
-export const daprApplicationId = () => {
+export const useDaprApplicationId = () => {
   const { entity } = useEntity();
 
   if (isDaprAvailable(entity)) {

--- a/plugins/dapr/src/utils/isDaprUiConfigured.ts
+++ b/plugins/dapr/src/utils/isDaprUiConfigured.ts
@@ -1,6 +1,6 @@
 import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
 
-export const daprUI = () => {
+export const useDaprUI = () => {
   const configApi = useApi(configApiRef);
   const daprUiUrl = configApi.getOptionalString('dapr.uiUrl');
   return daprUiUrl;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5702,6 +5702,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dapr/backstage-plugin-dapr@npm:^0.1.0, @dapr/backstage-plugin-dapr@workspace:plugins/dapr":
+  version: 0.0.0-use.local
+  resolution: "@dapr/backstage-plugin-dapr@workspace:plugins/dapr"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.7.3"
+    "@backstage/cli": "npm:^0.29.0"
+    "@backstage/core-app-api": "npm:^1.15.2"
+    "@backstage/core-compat-api": "npm:^0.3.5"
+    "@backstage/core-components": "npm:^0.16.1"
+    "@backstage/core-plugin-api": "npm:^1.10.1"
+    "@backstage/dev-utils": "npm:^1.1.4"
+    "@backstage/frontend-plugin-api": "npm:^0.9.4"
+    "@backstage/plugin-catalog-react": "npm:^1.15.1"
+    "@backstage/test-utils": "npm:^1.7.2"
+    "@backstage/theme": "npm:^0.6.2"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@testing-library/jest-dom": "npm:^6.0.0"
+    "@testing-library/react": "npm:^14.0.0"
+    "@testing-library/user-event": "npm:^14.0.0"
+    msw: "npm:^1.0.0"
+    react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+  languageName: unknown
+  linkType: soft
+
 "@date-io/core@npm:1.x, @date-io/core@npm:^1.3.13":
   version: 1.3.13
   resolution: "@date-io/core@npm:1.3.13"
@@ -6921,35 +6950,6 @@ __metadata:
   checksum: 10c0/80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
   languageName: node
   linkType: hard
-
-"@internal/backstage-plugin-dapr@npm:^0.1.0, @internal/backstage-plugin-dapr@workspace:plugins/dapr":
-  version: 0.0.0-use.local
-  resolution: "@internal/backstage-plugin-dapr@workspace:plugins/dapr"
-  dependencies:
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/cli": "npm:^0.29.0"
-    "@backstage/core-app-api": "npm:^1.15.2"
-    "@backstage/core-compat-api": "npm:^0.3.5"
-    "@backstage/core-components": "npm:^0.16.1"
-    "@backstage/core-plugin-api": "npm:^1.10.1"
-    "@backstage/dev-utils": "npm:^1.1.4"
-    "@backstage/frontend-plugin-api": "npm:^0.9.4"
-    "@backstage/plugin-catalog-react": "npm:^1.15.1"
-    "@backstage/test-utils": "npm:^1.7.2"
-    "@backstage/theme": "npm:^0.6.2"
-    "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
-    "@testing-library/jest-dom": "npm:^6.0.0"
-    "@testing-library/react": "npm:^14.0.0"
-    "@testing-library/user-event": "npm:^14.0.0"
-    msw: "npm:^1.0.0"
-    react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
-    react-use: "npm:^17.2.4"
-  peerDependencies:
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  languageName: unknown
-  linkType: soft
 
 "@ioredis/commands@npm:^1.1.1":
   version: 1.2.0
@@ -13776,7 +13776,7 @@ __metadata:
     "@backstage/plugin-user-settings": "npm:^0.8.15"
     "@backstage/test-utils": "npm:^1.7.1"
     "@backstage/theme": "npm:^0.6.1"
-    "@internal/backstage-plugin-dapr": "npm:^0.1.0"
+    "@dapr/backstage-plugin-dapr": "npm:^0.1.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@playwright/test": "npm:^1.32.3"


### PR DESCRIPTION
daprApplicationId() and daprUI() are as React Hook. So it must be start with 'use'