### PR TITLE
remove react from devDependencies

### DIFF
--- a/plugins/dapr/package.json
+++ b/plugins/dapr/package.json
@@ -48,8 +48,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
-    "msw": "^1.0.0",
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+    "msw": "^1.0.0"
   },
   "files": [
     "config.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5724,7 +5724,6 @@ __metadata:
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
     msw: "npm:^1.0.0"
-    react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-use: "npm:^17.2.4"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -27743,7 +27742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^16.13.1 || ^17.0.0 || ^18.0.0, react@npm:^18.0.2":
+"react@npm:^18.0.2":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:


### PR DESCRIPTION
react is specified as peerDependency in package.json, so it should be installed.