### PR TITLE
Need to specified the dependencies at useEffect hook

### DIFF
--- a/plugins/dapr/src/components/ApplicationActorsCard/ApplicationActorsCard.tsx
+++ b/plugins/dapr/src/components/ApplicationActorsCard/ApplicationActorsCard.tsx
@@ -46,7 +46,7 @@ export const ApplicationActorsCard = () => {
     };
 
     fetchData();
-  });
+  }, [applicationId, DaprAPI]);
 
   if (loading) {
     return <Typography>Loading...</Typography>;

--- a/plugins/dapr/src/components/ApplicationComponentsCard/ApplicationComponentsCard.tsx
+++ b/plugins/dapr/src/components/ApplicationComponentsCard/ApplicationComponentsCard.tsx
@@ -46,7 +46,7 @@ export const ApplicationComponentsCard = () => {
     };
 
     fetchData();
-  });
+  }, [applicationId, DaprAPI]);
 
   if (loading) {
     return <Typography>Loading...</Typography>;

--- a/plugins/dapr/src/components/ApplicationSubscriptionsCard/ApplicationSubscriptionsCard.tsx
+++ b/plugins/dapr/src/components/ApplicationSubscriptionsCard/ApplicationSubscriptionsCard.tsx
@@ -46,7 +46,7 @@ export const ApplicationSubscriptionsCard = () => {
     };
 
     fetchData();
-  });
+  }, [applicationId, DaprAPI]);
 
   if (loading) {
     return <Typography>Loading...</Typography>;


### PR DESCRIPTION
When I displayed `DaprEntityContent` page,
the  app fetched  metadata from api repeatedly.

Similar to `ApplicationSummaryCard`,  useEffect hook need to be have its dependencies specified (second argment)

see: https://react.dev/reference/react/useEffect#parameters

> If you omit this argument, your Effect will re-run after every re-render of the component.