### PR TITLE
add 'consumesApis' to example entities

### DIFF
--- a/examples/entities.yaml
+++ b/examples/entities.yaml
@@ -20,6 +20,11 @@ spec:
   owner: guests
   system: conference-application
   providesApis: [frontend-api]
+  consumesApis:
+    - agenda-service-api
+    - notifications-service-api
+    - c4p-service-api
+
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
@@ -64,6 +69,9 @@ spec:
   owner: guests
   system: conference-application
   providesApis: [c4p-service-api]
+  consumesApis:
+    - notifications-service-api
+    - agenda-service-api
 
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api


### PR DESCRIPTION
update backstage example catalog.
It is good to add 'consumesApis' for displaying dependencies like this.

![Screenshot 2025-05-05 at 19 55 03](https://github.com/user-attachments/assets/025d04b3-dce0-4f2d-84b1-bc6bbd66bfc7)
