### PR TITLE
Enable dependabot to check for updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
Check for updates to GitHub Actions every week.

GitHub recommend  to [keep actions up to date](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-dependabot-version-updates-to-keep-actions-up-to-date). 